### PR TITLE
VNC auth: align DES key setup with tightvnc to make login work

### DIFF
--- a/pytest_vnc.py
+++ b/pytest_vnc.py
@@ -129,7 +129,7 @@ def vnc(pytestconfig):
         if not passwd:
             raise ValueError('VNC server requires password')
         des_key = passwd.encode('ascii')[:8].ljust(8, b'\x00')
-        des_key = bytes(int(bin(n)[:1:-1], 2) for n in des_key)
+        des_key = bytes(int(bin(n)[:1:-1].ljust(8, '0'), 2) for n in des_key)
         encryptor = Cipher(TripleDES(des_key), ECB()).encryptor()
         sock.sendall(encryptor.update(read(sock, 16)) + encryptor.finalize())
 


### PR DESCRIPTION
pytest-vnc could not login to VNC servers (Debian Linux apt-get install tightvncserver), because the DES key setup was slightly different in pytest-vnc and the VNC server. This PR changes the bit-reversal in the DES key setup to always use 8 bits instead of losing leading zeros.

The code before the change maps certain character in the password to the same byte in DES key setup. This is avoided after the change - and the login to a tight VNC server works.

>>> des_key = b'1b'
>>> bytes(int(bin(n)[:1:-1], 2) for n in des_key)
b'##'
>>> bytes(int(bin(n)[:1:-1].ljust(8, '0'), 2) for n in des_key)
b'\x8cF'

Disclaimer: I do __not__ know if this change breaks the login into another kind of VNC server.