### PR TITLE
Increased minimum Python version to 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ license = GPL
 
 [options]
 py_modules = pytest_vnc
-python_requires = >= 3.7
+python_requires = >= 3.10
 install_requires =
     cryptography
     keysymdef


### PR DESCRIPTION
Commit 7243076c74789f679a47d39fdc03f0c02fcc6ef2 introduces the use of | in function annotations which was introduced in Python 3.10 ([PEP 604](https://peps.python.org/pep-0604/))